### PR TITLE
Fix for Captive Portal Notification

### DIFF
--- a/src/mobile-rr.ino
+++ b/src/mobile-rr.ino
@@ -642,13 +642,13 @@ void onRequest ( AsyncWebServerRequest *request )
 	if ( path.endsWith ( "/" ) )
 		path += "index.htm";
 
-	if ( !SPIFFS.exists ( path ) && !SPIFFS.exists ( path + ".gz" ) )
+	if ( ( !SPIFFS.exists ( path ) && !SPIFFS.exists ( path + ".gz" )) ||  (request->host() != "10.10.10.1") )
 	{
 		//AsyncWebHeader *h = request->getHeader ( "User-Agent" );
 
 		// Redirect to captive portal
 		//dbg_printf ( "HTTP[%d]: Redirected to captive portal\n%s", remoteIP[3], h->value().c_str() ) ;
-		request->redirect ( "http://freewifi.com/index.htm" );
+		request->redirect ( "http://10.10.10.1/index.htm" );
 	}
 	else
 	{


### PR DESCRIPTION
This fixed the Captive Portal Notification on Android for me. I also change the Redirect URL to the IP-Adress because the domain is already taken and loads an ugly page if you switch back to a working internet connection later.
