### PR TITLE
Faster flashing

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,6 +26,7 @@ framework = arduino
 board = d1_mini
 board_f_cpu = 160000000L
 build_flags = -ULWIP_OPEN_SRC -Wl,-Tesp8266.flash.4m.ld
-upload_speed = 115200
+# Set upload_speed to 115200 if 921600 does not work for you
+upload_speed = 921600
 lib_install = 64, 306
 #upload_port = 10.10.10.1


### PR DESCRIPTION
The D1 Mini does support a boudrate of 921600. This will result in faster flashing.
