### PR TITLE
Include libraries back in config

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,10 @@ framework = arduino
 board = d1_mini
 board_f_cpu = 160000000L
 build_flags = -ULWIP_OPEN_SRC -Wl,-Tesp8266.flash.4m.ld
-
+lib_deps = 
+	ArduinoJson
+	ESPAsyncTCP
+	ESPAsyncWebServer
 # Custom Script to run before building SPIFFS image
 extra_script = www_proc.py
 


### PR DESCRIPTION
This should install libraries automatically on first platformio run. 
Tested with PlatformIO 3.1.0
